### PR TITLE
add entrypoint.sh for setting default username and password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,12 @@ RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 EXPOSE 8090
 
+# Environment variables for admin credentials
+ENV PB_ADMIN_EMAIL=""
+ENV PB_ADMIN_PASSWORD=""
+
 COPY --from=downloader /pocketbase /usr/local/bin/pocketbase
-ENTRYPOINT ["/usr/local/bin/pocketbase", "serve", "--http=0.0.0.0:8090", "--dir=/pb_data", "--publicDir=/pb_public", "--hooksDir=/pb_hooks"]
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,42 @@ docker run -d \
   --encryptionEnv ENCRYPTION `# optional`
 ```
 
+## Configuring Admin Credentials
+
+You can configure a default admin user during container initialization by setting the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `PB_ADMIN_EMAIL` | Email address for the admin user |
+| `PB_ADMIN_PASSWORD` | Password for the admin user |
+
+### Using Docker Compose
+
+```yaml
+version: "3.7"
+services:
+  pocketbase:
+    image: ghcr.io/muchobien/pocketbase:latest
+    environment:
+      PB_ADMIN_EMAIL: "admin@example.com"
+      PB_ADMIN_PASSWORD: "your-secure-password"
+    # ... other configuration ...
+```
+
+### Using Docker CLI
+
+```bash
+docker run -d \
+  --name=pocketbase \
+  -p 8090:8090 \
+  -e PB_ADMIN_EMAIL=admin@example.com \
+  -e PB_ADMIN_PASSWORD=your-secure-password \
+  -v /path/to/data:/pb_data \
+  ghcr.io/muchobien/pocketbase:latest
+```
+
+**Note**: If either of these environment variables is not set, the container will start normally without creating an admin user.
+
 ## Building the Image Locally
 
 To build the image yourself, copy the `Dockerfile` and `docker-compose.yml` to your project directory. Update `docker-compose.yml` to build the image instead of pulling it:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+# Function to create superuser
+create_superuser() {
+    # Initialize the database
+    /usr/local/bin/pocketbase --dir=/pb_data migrate
+
+    # Attempt to create superuser
+    if /usr/local/bin/pocketbase --dir=/pb_data superuser create "$PB_ADMIN_EMAIL" "$PB_ADMIN_PASSWORD"; then
+        echo "Successfully created default admin user"
+    else
+        echo "Failed to create admin user. Check if user already exists or if there are any other errors in the container logs."
+    fi
+}
+
+# Create superuser if environment variables are set
+if [ -n "$PB_ADMIN_EMAIL" ] && [ -n "$PB_ADMIN_PASSWORD" ]; then
+    echo "Attempting to create default admin user: $PB_ADMIN_EMAIL"
+    create_superuser
+fi
+
+# Start PocketBase server
+exec /usr/local/bin/pocketbase serve --http=0.0.0.0:8090 --dir=/pb_data --publicDir=/pb_public --hooksDir=/pb_hooks


### PR DESCRIPTION
Closes #31 

### How to test
1. checkout the branch
2. build the container

```bash
docker build --build-arg VERSION=0.25.5 -t pocketbase-test .
```

3. run it
```bash
docker run -d \
  --name pocketbase-test \
  -p 8090:8090 \
  -e PB_ADMIN_EMAIL=admin@example.com \
  -e PB_ADMIN_PASSWORD=adminpass123 \
  pocketbase-test
```

4. attempt to login http://0.0.0.0:8090/_/#/login with username `admin@example.com` and password `adminpass123` 