### PR TITLE
feat: use exact Alpine version latest 3.24.1 & add Dependabot tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
       interval: "daily"
 
   # Track Alpine base image updates so OS-level security patches (e.g. OpenSSL CVEs)
-  # get picked up promptly without waiting for a new PocketBase release
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  # Track Alpine base image updates so OS-level security patches (e.g. OpenSSL CVEs)
+  # get picked up promptly without waiting for a new PocketBase release
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3 AS downloader
+FROM alpine:3.24.1 AS downloader
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -11,7 +11,7 @@ RUN wget https://github.com/pocketbase/pocketbase/releases/download/v${VERSION}/
     && unzip pocketbase_${VERSION}_${BUILDX_ARCH}.zip \
     && chmod +x /pocketbase
 
-FROM alpine:3
+FROM alpine:3.24.1
 RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
 
 COPY --from=downloader /pocketbase /usr/local/bin/pocketbase


### PR DESCRIPTION
Changing the FROM line to the exact version tag lets Dependabot open PRs when new Alpine releases ship, ensuring OS-level security patches get picked up without waiting for a new PocketBase release.

This was prompted by a security scan on a PR to one of my repos that found the latest version of this container has CVE-2026-34182 that was fixed in Alpine 3.5.7.

Fixes #53 